### PR TITLE
Fix socket 2 current-limit writes, idle 5 kW ghost reading, and missing slider listener

### DIFF
--- a/drivers/chargepoint/device.ts
+++ b/drivers/chargepoint/device.ts
@@ -228,6 +228,10 @@ module.exports = class MyDevice extends Homey.Device {
     this.registerCapabilityListener('chargeid', async (value) => {
       await this.#setChargeID(value);
     });
+
+    this.registerCapabilityListener('measure_current.limit', async (value) => {
+      await this.#setCurrentLimit(Number(value));
+    });
   }
 
   async #registerFlowCardListeners() {

--- a/drivers/chargepoint/device.ts
+++ b/drivers/chargepoint/device.ts
@@ -377,11 +377,11 @@ module.exports = class MyDevice extends Homey.Device {
   }
 
   async #setCurrentLimit(value: number) {
-    this.log('setCurrentLimit', value);
+    this.log('setCurrentLimit', value, 'socket', this.socketIndex);
 
     try {
       await this.alfenApi.apiLogin();
-      await this.alfenApi.apiSetCurrentLimit(value);
+      await this.alfenApi.apiSetCurrentLimit(value, this.socketIndex);
     } catch (error) {
       this.log('Error setting current limit:', error);
       throw new Error(`${error}`);

--- a/lib/AlfenApi.ts
+++ b/lib/AlfenApi.ts
@@ -488,8 +488,10 @@ export class AlfenApi {
       if (capabilityId.startsWith('measure_current')) return { value: Math.round(v * 10) / 10 };
 
       if (capabilityId.startsWith('measure_power')) {
-        const watts = v > 0 && v <= 200 ? v * 1000 : v;
-        return { value: Math.round(watts * 10) / 10 };
+        // Alfen returns real power in Watts (property 2221_16 and its per-phase variants).
+        // A previous heuristic multiplied small values by 1000, which turned idle
+        // standby (~5 W) into a ghost 5 kW reading on the dashboard. See issue #24.
+        return { value: Math.round(v * 10) / 10 };
       }
 
       if (capabilityId === Cap.MeterPower) return { value: Math.round(v / 10) / 100 };

--- a/lib/AlfenApi.ts
+++ b/lib/AlfenApi.ts
@@ -9,7 +9,7 @@ import { HttpsPromiseOptions, HttpsPromiseResponse, PropertyResponseBody } from 
 import { InfoResponse } from './models/InfoResponse';
 import { ChargerSocketsInfo, SocketType, parseChargerSocketsInfo } from './models/SocketType';
 import { ChargerDetails } from './models/ChargerDetails';
-import { SocketIndex, buildIds, getActualValuePropIds, getCapabilityMap, normalizeApiId } from './alfenProps';
+import { SocketIndex, alfenProps, buildIds, forSocket, getActualValuePropIds, getCapabilityMap, normalizeApiId, propIdToApiId } from './alfenProps';
 import { Cap, type CapabilityId } from './homeyCapabilities';
 
 const apiHeader: string = 'alfen/json; charset=utf-8';
@@ -238,13 +238,16 @@ export class AlfenApi {
     return capabilitiesData;
   }
 
-  async apiSetCurrentLimit(currentLimit: number) {
+  async apiSetCurrentLimit(currentLimit: number, socketIndex: SocketIndex = 1) {
     if (currentLimit < 1 || currentLimit > 32) return false;
+
+    // Socket 1 -> "2129_0"; Socket 2 -> "3129_0" (see alfenProps.forSocket)
+    const apiId = propIdToApiId(forSocket(alfenProps.socketBase.currentLimit, socketIndex));
 
     // Define the request body
     const body = JSON.stringify({
-      '2129_0': {
-        id: '2129_0',
+      [apiId]: {
+        id: apiId,
         value: currentLimit,
       },
     });
@@ -252,7 +255,7 @@ export class AlfenApi {
     try {
       await this.#apiSetProperty(body);
     } catch (e) {
-      throw new Error(`Error setting current limit: ${e}`);
+      throw new Error(`Error setting current limit (socket ${socketIndex}): ${e}`);
     }
 
     return true;

--- a/lib/alfenProps.ts
+++ b/lib/alfenProps.ts
@@ -101,10 +101,10 @@ export const alfenProps = {
     currentL2: 0x22210b, // A
     currentL3: 0x22210c, // A
 
-    powerRealL1: 0x222113, // kW
-    powerRealL2: 0x222114, // kW
-    powerRealL3: 0x222115, // kW
-    powerRealTotal: 0x222116, // kW
+    powerRealL1: 0x222113, // W
+    powerRealL2: 0x222114, // W
+    powerRealL3: 0x222115, // W
+    powerRealTotal: 0x222116, // W
 
     energyDeliveredTotal: 0x222122, // kWh
 


### PR DESCRIPTION
## Context

Setup: Alfen Eve Double Pro-line, paired as two Homey devices. Controlling the current limit per socket from a HomeyScript. On the second socket the limit would stick at whatever the first socket was set to. The cause is in the source.

## Commit 1: apiSetCurrentLimit respects socketIndex

`lib/AlfenApi.ts` had:

```ts
async apiSetCurrentLimit(currentLimit: number) {
  if (currentLimit < 1 || currentLimit > 32) return false;
  const body = JSON.stringify({
    '2129_0': { id: '2129_0', value: currentLimit },  // hardcoded socket 1
  });
  ...
}
```

Callers in `drivers/chargepoint/device.ts` never passed `socketIndex`, so every write on a Duo's second device landed on socket 1's property. PR #19 made the read path socket-aware via `forSocket()`, but the write path was not updated.

Repro: on a paired Duo, trigger the "Set current limit" action on the second device with e.g. 6 A, then check in the Alfen Service Installer that `3129_0` is unchanged while `2129_0` changed.

Fix: thread `socketIndex` through `apiSetCurrentLimit`, select the correct api id via the existing `forSocket()` + `propIdToApiId()` helpers. `socketIndex` defaults to 1 so single-charger installs see no behavioural change.

Other per-socket writeables (`authMode`, `chargeID`) are station-wide (2xxx_0) so are unaffected. Solar / `chargeType` / `greenShare` / `comfortChargeLevel` are socket-1 only per Alfen firmware, and `#removeSolarCapabilitiesForDuo` already strips them from Duo devices.

## Commit 2: idle measure_power ghost 5 kW (closes #24)

```ts
const watts = v > 0 && v <= 200 ? v * 1000 : v;
```

Alfen's `2221_16` (powerRealTotal) is already in Watts. Same property in `leeyuentuen/alfen_wallbox` (HA) is typed `UnitOfPower.WATT`. The heuristic multiplies any value <= 200 by 1000, so idle standby (~5 W) renders as 5 kW on the Homey energy dashboard.

Fix: drop the heuristic. Also corrected the `// kW` comments in `alfenProps.ts` to `// W`.

## Commit 3: slider for measure_current.limit was a no-op

`measure_current.limit` is declared `"setable": true` in `driver.compose.json`, but there was no `registerCapabilityListener('measure_current.limit', ...)` in `device.ts`. Moving the slider in the device tile fired nothing. The flow action card worked because it uses `getActionCard` separately.

Fix: add the listener, routed through the existing `#setCurrentLimit` helper. Picks up the socket-aware behaviour from commit 1 on Duo.

Side note, not in this PR: `measure_current.limit` has `"max": 16` in compose, but `apiSetCurrentLimit` validates 1-32 and the flow card accepts 1-32. Eve Single supports up to 32 A.

## Verification

- `npx tsc --noEmit` passes on each commit.
- Changes follow the `forSocket()` / `propIdToApiId()` pattern from #19.
- Default argument keeps single-socket behaviour unchanged.

## Not bundled

- #25 (MyEVE slider stale after Homey writes) looks client-side in MyEVE. Writing `2129_0` takes effect immediately and charging reaches the new setpoint.
- #20 (`evcharger_charging` missing listener): Alfen has no native pause/resume, confirmed against `alfen_wallbox`. Needs a call between a no-op listener with an explanatory error vs. a current-limit-1A proxy. Can follow up once you pick a direction.
- `refreshDevice` calls `apiLogout` in a finally block even when `apiLogin` threw, which can null-deref `#agent`. Plausibly related to stalls in #4 / #12. Separate PR if wanted.
