### PR TITLE
Null-safety on session path; fix silent stale state and session leak

### DIFF
--- a/drivers/chargepoint/device.ts
+++ b/drivers/chargepoint/device.ts
@@ -95,11 +95,14 @@ module.exports = class MyDevice extends Homey.Device {
 
     try {
       await this.alfenApi.apiLogin();
-      result = await this.alfenApi.apiGetActualValues(this.socketIndex);
+      try {
+        result = await this.alfenApi.apiGetActualValues(this.socketIndex);
+      } finally {
+        // Only logout when login actually succeeded.
+        await this.alfenApi.apiLogout();
+      }
     } catch (error) {
       this.log('Error refreshing device:', error);
-    } finally {
-      await this.alfenApi.apiLogout();
     }
 
     if (result == null) return;
@@ -147,8 +150,35 @@ module.exports = class MyDevice extends Homey.Device {
 
     this.socketIndex = Number(settings.socketIndex ?? 1) === 2 ? 2 : 1;
 
+    // Close the previous session before replacing the client, otherwise the old
+    // undici Pool stays alive and the charger sees a stale logged-in session.
+    if (this.alfenApi) {
+      try {
+        await this.alfenApi.apiLogout();
+      } catch (err) {
+        this.log('Logout of previous AlfenApi failed (ignored):', err);
+      }
+    }
+
     this.alfenApi = new AlfenApi(this.log, settings.ip, settings.username, settings.password);
     this.log(`Using socketIndex: ${this.socketIndex}`);
+  }
+
+  /**
+   * onDeleted is called when the user deletes the device.
+   */
+  async onDeleted() {
+    if (this.currentInterval) {
+      clearInterval(this.currentInterval);
+      this.currentInterval = null;
+    }
+    if (this.alfenApi) {
+      try {
+        await this.alfenApi.apiLogout();
+      } catch (err) {
+        this.log('Logout on delete failed (ignored):', err);
+      }
+    }
   }
 
   /**
@@ -158,13 +188,6 @@ module.exports = class MyDevice extends Homey.Device {
    */
   async onRenamed(name: string) {
     this.log('MyDevice was renamed');
-  }
-
-  /**
-   * onDeleted is called when the user deleted the device.
-   */
-  async onDeleted() {
-    this.log('MyDevice has been deleted');
   }
 
   /** Helper Functions */

--- a/lib/AlfenApi.ts
+++ b/lib/AlfenApi.ts
@@ -98,6 +98,14 @@ export class AlfenApi {
     if (this.#retrieving > 0) return;
     if (this.#retrieving < 0) this.#retrieving = 0;
 
+    // Nothing to tear down. This happens when a prior apiLogin() threw
+    // (which already nulled #agent); we must not attempt an HTTPS call
+    // against a null pool.
+    if (!this.#agent) {
+      this.#log('No active session, logout skipped.');
+      return;
+    }
+
     this.#log(`Logout procedure, logout & clean-up agent.`);
 
     // Define the options for the HTTPS request
@@ -176,7 +184,13 @@ export class AlfenApi {
       throw new Error(`Request failed: ${error}`);
     }
 
-    if (bodyResult === undefined) return capabilitiesData;
+    // A successful HTTP 200 but missing/malformed body means the session is
+    // live but the charger returned something we cannot parse. Treat as an
+    // error so the caller can invalidate and retry; silently returning [] here
+    // would leave Homey showing stale capability values indefinitely.
+    if (bodyResult === undefined || !Array.isArray(bodyResult?.properties)) {
+      throw new Error('apiGetActualValues: unexpected response body (no properties array).');
+    }
 
     // Handle the response
     const result = bodyResult.properties;
@@ -409,7 +423,11 @@ export class AlfenApi {
       requestOptions.headers = { Connection: 'keep-alive', ...requestOptions.headers };
     }
 
-    const res = await this.#agent!.request({
+    if (!this.#agent) {
+      throw new Error('No active session: apiLogin() required before making requests.');
+    }
+
+    const res = await this.#agent.request({
       path: requestOptions.path,
       method: requestOptions.method,
       headers: {

--- a/lib/alfenProps.ts
+++ b/lib/alfenProps.ts
@@ -106,7 +106,9 @@ export const alfenProps = {
     powerRealL3: 0x222115, // kW
     powerRealTotal: 0x222116, // kW
 
-    energyDeliveredTotal: 0x222122, // kWh
+    // Alfen returns this in Wh; AlfenApi.#normalizeCapabilityValue divides by 1000 for Homey's meter_power (kWh).
+    // Verified against leeyuentuen/alfen_wallbox (sensor.py, prop "2221_22": "meter_reading from w to kWh" -> prop[VALUE] / 1000).
+    energyDeliveredTotal: 0x222122, // Wh
 
     energyConsumedL1: 0x222123,
     energyConsumedL2: 0x222124,


### PR DESCRIPTION
## Context

Follow-up to #26. This PR is independent of that one (different files, no overlap). Focus: null-safety and error propagation on the session path. Plus one doc-only unit-comment fix.

All three commits are tightly related to how a single failed request cascades through the rest of the session lifecycle. I verified the claims against `leeyuentuen/alfen_wallbox` (HA integration) where behaviour is comparable.

## Commit 1: refresh lifecycle and session cleanup in MyDevice

`drivers/chargepoint/device.ts`:

- **`refreshDevice`**: the `finally { await this.alfenApi.apiLogout(); }` block ran unconditionally, including when `apiLogin` had thrown. In that path, `apiLogin` already nulled `#agent` before rethrowing, so the subsequent `apiLogout` went on to invoke `#httpsPromise` against a null pool. That produced a TypeError that the outer silent catch absorbed. Split the try/finally so logout only runs when login succeeded.
- **`onSettings`**: it replaced `this.alfenApi` with a fresh instance without logging out the old one. The old undici Pool and logged-in charger session leaked until GC. Added a `try { apiLogout } catch { log }` before replacement.
- **`onDeleted`**: previously a no-op log line. Now clears the poll interval and logs out the session, so removing the device doesn't leave a stale session on the charger and doesn't keep the 30s interval firing on a dead `AlfenApi`.

## Commit 2: null-safety and error propagation in AlfenApi session path

`lib/AlfenApi.ts`, three related fixes:

- **`apiLogout`**: short-circuits cleanly when `#agent` is already null, instead of calling `#httpsPromise` which would deref the null pool. Keeps the ref-counter cleanup (`#retrieving` decrement) but skips the HTTPS dance.
- **`#httpsPromise`**: removed the non-null assertion `this.#agent!.request(...)`. Replaced with an explicit guard that throws `"No active session: apiLogin() required before making requests."`. Callers can distinguish this from a generic TypeError.
- **`apiGetActualValues`**: previously returned an empty `[]` when `bodyResult` was undefined. The caller ran `updateCapabilities([])` and nothing changed, so the Homey tile kept showing stale values with no error signal. Throw instead, so the caller can log/retry. The `bodyResult?.properties` array-check also catches malformed responses. This behaviour pattern matches #4 ("values not updated after a certain amount of time") better than the silent-stale fallback did.

## Commit 3: correct unit comment on energyDeliveredTotal

`lib/alfenProps.ts`:

`#normalizeCapabilityValue` divides this raw value by 1000 for Homey's `meter_power` (kWh). That math only works if the charger returns Wh. Confirmed against `leeyuentuen/alfen_wallbox` ([sensor.py:2126-2127](https://github.com/leeyuentuen/alfen_wallbox/blob/main/custom_components/alfen_wallbox/sensor.py#L2126)) which does the same `/1000` with the comment `"meter_reading from w to kWh"`.

Comment-only change, no behaviour difference. Prevents a future maintainer from repeating the kW/W confusion that produced the ghost 5 kW `measure_power` reading (#24).

## Verification

- `npx tsc --noEmit` passes on each commit and at tip.
- No behavioural change for the happy path. All changes are either guards on failure paths, or a comment.
- Cross-referenced against `leeyuentuen/alfen_wallbox` (HA integration):
  - HA uses the same `/1000` for `2221_22` with comment `"from w to kWh"`.
  - HA logs out on setting change (`__init__.py` coordinator shutdown).

## Not included

The audit that led to this PR also flagged the per-poll login/logout pattern (2880 logins/day per socket) as a likely contributor to #4 and #12. Changing that is a larger refactor (persistent session with rate-limit and 401-retry, similar to HA's `_proactive_login`) and deserves its own PR and design discussion. I'll draft that separately.

This PR is intentionally low-risk: only failure-path guards and a comment. It won't on its own fix #4 or #12, but it removes one class of silent cascading errors that make diagnosing those issues harder.
