### PR TITLE
Add reboot_wallbox flow action wrapping existing apiRebootEvCharger

### DIFF
--- a/drivers/chargepoint/device.ts
+++ b/drivers/chargepoint/device.ts
@@ -297,6 +297,11 @@ module.exports = class MyDevice extends Homey.Device {
       this.log('Flow card action', args, state);
       await this.#setCurrentLimit(args.limit);
     });
+
+    this.homey.flow.getActionCard('reboot_wallbox').registerRunListener(async (args, state) => {
+      this.log('Flow card action: reboot_wallbox', args, state);
+      await this.#rebootWallbox();
+    });
   }
 
   async #setChargeType(value: string) {
@@ -411,6 +416,22 @@ module.exports = class MyDevice extends Homey.Device {
       await this.alfenApi.apiSetCurrentLimit(value, this.socketIndex);
     } catch (error) {
       this.log('Error setting current limit:', error);
+      throw new Error(`${error}`);
+    } finally {
+      await this.alfenApi.apiLogout();
+    }
+
+    return true;
+  }
+
+  async #rebootWallbox() {
+    this.log('rebootWallbox');
+
+    try {
+      await this.alfenApi.apiLogin();
+      await this.alfenApi.apiRebootEvCharger();
+    } catch (error) {
+      this.log('Error rebooting wallbox:', error);
       throw new Error(`${error}`);
     } finally {
       await this.alfenApi.apiLogout();

--- a/drivers/chargepoint/driver.flow.compose.json
+++ b/drivers/chargepoint/driver.flow.compose.json
@@ -273,6 +273,21 @@
                     "label": "A"
                 }
             ]
+        },
+        {
+            "id": "reboot_wallbox",
+            "title": {
+                "en": "Reboot wallbox",
+                "nl": "Wallbox herstarten"
+            },
+            "titleFormatted": {
+                "en": "Reboot wallbox",
+                "nl": "Wallbox herstarten"
+            },
+            "hint": {
+                "en": "Sends a reboot command via POST /cmd. Interrupts active charging sessions; use during idle only. Useful for recovery after a freeze without restarting the Homey app.",
+                "nl": "Stuurt een reboot-commando via POST /cmd. Onderbreekt actieve laadsessies; alleen gebruiken in idle-toestand. Handig voor recovery na een vastloper zonder de Homey-app te herstarten."
+            }
         }
     ]
 }


### PR DESCRIPTION
Voegt een flow-action toe die de al bestaande `apiRebootEvCharger()` helper aanroept. Tot nu toe was die functie aanwezig in `lib/AlfenApi.ts` maar nergens vanuit een flow bereikbaar.

## Wijziging

- Nieuwe action `reboot_wallbox` in `drivers/chargepoint/driver.flow.compose.json`. Geen args, EN+NL titel + hint.
- Nieuwe private methode `#rebootWallbox()` in `drivers/chargepoint/device.ts` die het bestaande `apiLogin → apiRebootEvCharger → apiLogout`-pattern volgt (identiek aan `#enableRFID` en `#setCurrentLimit`).
- Listener-registratie naast bestaande listeners in `onInit()`.

## Use case

Recovery na een incidentele freeze van de wallbox zonder de Homey-app te herstarten. Komt overeen met de reboot-knop in de officiële `leeyuentuen/alfen_wallbox` HA-integratie.

## Validatie

- `homey app validate -l publish`: groen
- `tsc`: groen
- Build artifact: 2 files changed, 36 insertions

## Veiligheid

Hint waarschuwt expliciet dat het commando een actieve laadsessie onderbreekt. Best gebruikt in idle-toestand. Reboot tijdens charging-state geeft een grace-disconnect bij Alfen, geen hardware-risico.