### PR TITLE
Add measure_frequency and measure_current.activelb sensors

### DIFF
--- a/drivers/chargepoint/driver.compose.json
+++ b/drivers/chargepoint/driver.compose.json
@@ -23,6 +23,8 @@
     "measure_power.l3",
     "measure_current.limit",
     "measure_current.stationlimit",
+    "measure_current.activelb",
+    "measure_frequency",
     "greenshare",
     "comfortchargelevel",
     "chargetype",
@@ -65,6 +67,18 @@
       "title": {
         "en": "Current Limit Station",
         "nl": "Stroomsterkte Limiet Station"
+      }
+    },
+    "measure_current.activelb": {
+      "title": {
+        "en": "Active load-balancing limit",
+        "nl": "Actieve load-balancing limiet"
+      }
+    },
+    "measure_frequency": {
+      "title": {
+        "en": "Grid frequency",
+        "nl": "Netfrequentie"
       }
     },
     "measure_voltage.l1": {

--- a/lib/alfenProps.ts
+++ b/lib/alfenProps.ts
@@ -88,11 +88,20 @@ export const alfenProps = {
       2: 0x250202,
     },
   },
+  loadbalancing: {
+    // Active LB max current per socket (Ampere). HA: api_param "212C_0" / "212D_0".
+    activeMaxCurrent: {
+      1: 0x212c00,
+      2: 0x212d00,
+    },
+  },
   // Socket-1 base values (socket-2 computed via forSocket)
   socketBase: {
     currentLimit: 0x212900, // A
 
     //Socket 1 values, for socket wil be calc
+    frequency: 0x222112, // Hz (HA api_param "2221_12")
+
     voltageL1: 0x222103, // V
     voltageL2: 0x222104, // V
     voltageL3: 0x222105, // V
@@ -143,6 +152,8 @@ export function getActualValuePropIds(socketIndex: SocketIndex): PropId[] {
   // Numeric meter candidates (socket 1 ids).
   // For socket 2 we transform them via forSocket(id, 2).
   const meterCandidates: number[] = [
+    s.frequency,
+
     s.voltageL1,
     s.voltageL2,
     s.voltageL3,
@@ -167,14 +178,17 @@ export function getActualValuePropIds(socketIndex: SocketIndex): PropId[] {
     s.energyConsumedL3,
   ];
 
+  // Active LB max current (explicit per-socket prop id, NOT via forSocket offset)
+  const lbCurrent: PropId[] = [alfenProps.loadbalancing.activeMaxCurrent[socketIndex]];
+
   if (socketIndex === 1) {
-    return unique([...shared, ...solarSocket1Only, ...statusSocket1, ...meterCandidates]);
+    return unique([...shared, ...solarSocket1Only, ...statusSocket1, ...meterCandidates, ...lbCurrent]);
   }
 
   // Socket 2+: no solar/greenshare
   const meterSocket2: PropId[] = meterCandidates.map((id) => forSocket(id, 2));
 
-  return unique([...shared, ...statusSocket2, ...meterSocket2]);
+  return unique([...shared, ...statusSocket2, ...meterSocket2, ...lbCurrent]);
 }
 
 /**
@@ -196,7 +210,9 @@ export function getCapabilityMap(socketIndex: SocketIndex): Record<string, Capab
     [propIdToApiId(alfenProps.solar.comfortChargeLevel)]: Cap.ComfortChargeLevel,
 
     [propIdToApiId(alfenProps.status.operatingMode[socketIndex])]: Cap.OperatingMode,
+    [propIdToApiId(alfenProps.loadbalancing.activeMaxCurrent[socketIndex])]: Cap.CurrentActiveLb,
     [propIdToApiId(forSocket(s.currentLimit, socketIndex))]: Cap.CurrentLimit,
+    [propIdToApiId(forSocket(s.frequency, socketIndex))]: Cap.MeasureFrequency,
 
     [propIdToApiId(forSocket(s.voltageL1, socketIndex))]: Cap.MeasureVoltageL1,
     [propIdToApiId(forSocket(s.voltageL2, socketIndex))]: Cap.MeasureVoltageL2,

--- a/lib/homeyCapabilities.ts
+++ b/lib/homeyCapabilities.ts
@@ -29,6 +29,9 @@ export const Cap = {
 
   CurrentLimit: 'measure_current.limit',
   StationLimit: 'measure_current.stationlimit',
+  CurrentActiveLb: 'measure_current.activelb',
+
+  MeasureFrequency: 'measure_frequency',
 } as const;
 
 export type CapabilityId = (typeof Cap)[keyof typeof Cap];


### PR DESCRIPTION
Twee read-only sensoren die al in de device-report zitten maar nog niet werden uitgelezen.

## Wijziging

- `measure_frequency`: netfrequentie in Hz, prop `2221_12` (socket 1) / `3221_12` (socket 2 via forSocket).
- `measure_current.activelb`: actieve load-balancing limiet in A, prop `212C_0` (socket 1) / `212D_0` (socket 2). Per-socket prop-ids zijn explicit (geen forSocket-offset).

## Bron

`leeyuentuen/alfen_wallbox/sensor.py:347-353` (frequency, api_param "2221_12") en `sensor.py:872-878` (LB max current, api_param "212C_0"). Read-only, zelfde polling-pad als bestaande sensoren.

## Use case

Onderscheid maken tussen Alfen's eigen LB-throttle en Homey-flow throttle. Frequency is bonus voor power-quality monitoring.

## Validatie

- `homey app validate -l publish`: groen
- `tsc`: groen
- 3 files changed, +35/-2

## Wijzigingen per file

- `lib/homeyCapabilities.ts`: 2 nieuwe `Cap` entries (`MeasureFrequency`, `CurrentActiveLb`).
- `lib/alfenProps.ts`: nieuwe `loadbalancing.activeMaxCurrent` group + `frequency` in `socketBase`. Toegevoegd aan `getActualValuePropIds` en `getCapabilityMap`.
- `drivers/chargepoint/driver.compose.json`: 2 capabilities + capabilitiesOptions met EN+NL titles.