### PR TITLE
Add P1 smart-meter current sensors per phase

### DIFF
--- a/drivers/chargepoint/driver.compose.json
+++ b/drivers/chargepoint/driver.compose.json
@@ -23,6 +23,9 @@
     "measure_power.l3",
     "measure_current.limit",
     "measure_current.stationlimit",
+    "measure_current.p1l1",
+    "measure_current.p1l2",
+    "measure_current.p1l3",
     "greenshare",
     "comfortchargelevel",
     "chargetype",
@@ -65,6 +68,24 @@
       "title": {
         "en": "Current Limit Station",
         "nl": "Stroomsterkte Limiet Station"
+      }
+    },
+    "measure_current.p1l1": {
+      "title": {
+        "en": "P1 meter current L1",
+        "nl": "P1-meter stroomsterkte L1"
+      }
+    },
+    "measure_current.p1l2": {
+      "title": {
+        "en": "P1 meter current L2",
+        "nl": "P1-meter stroomsterkte L2"
+      }
+    },
+    "measure_current.p1l3": {
+      "title": {
+        "en": "P1 meter current L3",
+        "nl": "P1-meter stroomsterkte L3"
       }
     },
     "measure_voltage.l1": {

--- a/lib/alfenProps.ts
+++ b/lib/alfenProps.ts
@@ -88,6 +88,13 @@ export const alfenProps = {
       2: 0x250202,
     },
   },
+  smartMeter: {
+    // P1 / external smart-meter currents per phase (Ampere). Station-wide.
+    // HA: api_param "212F_1" / "212F_2" / "212F_3" (sensor.py:553-577).
+    p1CurrentL1: 0x212f01,
+    p1CurrentL2: 0x212f02,
+    p1CurrentL3: 0x212f03,
+  },
   // Socket-1 base values (socket-2 computed via forSocket)
   socketBase: {
     currentLimit: 0x212900, // A
@@ -130,7 +137,15 @@ export function getActualValuePropIds(socketIndex: SocketIndex): PropId[] {
   const s = alfenProps.socketBase;
 
   // Shared / station-wide (not socket dependent)
-  const shared: PropId[] = [alfenProps.general.temperatureInternal, alfenProps.general.stationLimit, alfenProps.general.authMode, alfenProps.general.chargeID];
+  const shared: PropId[] = [
+    alfenProps.general.temperatureInternal,
+    alfenProps.general.stationLimit,
+    alfenProps.general.authMode,
+    alfenProps.general.chargeID,
+    alfenProps.smartMeter.p1CurrentL1,
+    alfenProps.smartMeter.p1CurrentL2,
+    alfenProps.smartMeter.p1CurrentL3,
+  ];
 
   // Solar / GreenShare: ONLY for socket 1
   const solarSocket1Only: PropId[] = [alfenProps.solar.chargeType, alfenProps.solar.greenShare, alfenProps.solar.comfortChargeLevel];
@@ -208,5 +223,10 @@ export function getCapabilityMap(socketIndex: SocketIndex): Record<string, Capab
 
     [propIdToApiId(forSocket(s.powerRealTotal, socketIndex))]: Cap.MeasurePower,
     [propIdToApiId(forSocket(s.energyDeliveredTotal, socketIndex))]: Cap.MeterPower,
+
+    // P1 / external smart-meter currents per phase (station-wide; same prop-id on socket-1 & socket-2 devices)
+    [propIdToApiId(alfenProps.smartMeter.p1CurrentL1)]: Cap.P1CurrentL1,
+    [propIdToApiId(alfenProps.smartMeter.p1CurrentL2)]: Cap.P1CurrentL2,
+    [propIdToApiId(alfenProps.smartMeter.p1CurrentL3)]: Cap.P1CurrentL3,
   };
 }

--- a/lib/homeyCapabilities.ts
+++ b/lib/homeyCapabilities.ts
@@ -29,6 +29,10 @@ export const Cap = {
 
   CurrentLimit: 'measure_current.limit',
   StationLimit: 'measure_current.stationlimit',
+
+  P1CurrentL1: 'measure_current.p1l1',
+  P1CurrentL2: 'measure_current.p1l2',
+  P1CurrentL3: 'measure_current.p1l3',
 } as const;
 
 export type CapabilityId = (typeof Cap)[keyof typeof Cap];


### PR DESCRIPTION
Drie read-only sensoren voor de P1 / externe smart-meter stromen per fase die de wallbox al rapporteert maar nog niet beschikbaar maakt in Homey.

## Wijziging

- `measure_current.p1l1`: prop `212F_1`
- `measure_current.p1l2`: prop `212F_2`
- `measure_current.p1l3`: prop `212F_3`

Station-wide (niet per socket), dus opgenomen in de `shared`-lijst in `getActualValuePropIds`.

## Bron

`leeyuentuen/alfen_wallbox/sensor.py:553-577`. Read-only, zelfde polling-pad als bestaande sensoren.

## Use case

Cross-check tegen een Athom P1-dongle in dynamic load-balancing flows. Geeft inzicht in de werkelijke huisbelasting via de wallbox-meting in plaats van een aparte P1-bron.

## Validatie

- `homey app validate -l publish`: groen
- `tsc`: groen
- 3 files changed, +46/-1

## Wijzigingen per file

- `lib/homeyCapabilities.ts`: 3 nieuwe `Cap` entries (`P1CurrentL1/L2/L3`).
- `lib/alfenProps.ts`: nieuwe `smartMeter` group + uitbreiding van `shared`-lijst en `getCapabilityMap`.
- `drivers/chargepoint/driver.compose.json`: 3 capabilities + capabilitiesOptions met EN+NL titles.