### PR TITLE
Add pause_charging and resume_charging flow actions

### DIFF
--- a/drivers/chargepoint/device.ts
+++ b/drivers/chargepoint/device.ts
@@ -297,6 +297,16 @@ module.exports = class MyDevice extends Homey.Device {
       this.log('Flow card action', args, state);
       await this.#setCurrentLimit(args.limit);
     });
+
+    this.homey.flow.getActionCard('pause_charging').registerRunListener(async (args, state) => {
+      this.log('Flow card action: pause_charging', args, state);
+      await this.#pauseCharging();
+    });
+
+    this.homey.flow.getActionCard('resume_charging').registerRunListener(async (args, state) => {
+      this.log('Flow card action: resume_charging', args, state);
+      await this.#resumeCharging();
+    });
   }
 
   async #setChargeType(value: string) {
@@ -411,6 +421,38 @@ module.exports = class MyDevice extends Homey.Device {
       await this.alfenApi.apiSetCurrentLimit(value, this.socketIndex);
     } catch (error) {
       this.log('Error setting current limit:', error);
+      throw new Error(`${error}`);
+    } finally {
+      await this.alfenApi.apiLogout();
+    }
+
+    return true;
+  }
+
+  async #pauseCharging() {
+    this.log('pauseCharging');
+
+    try {
+      await this.alfenApi.apiLogin();
+      await this.alfenApi.apiSetOperativeMode(2);
+    } catch (error) {
+      this.log('Error pausing charging:', error);
+      throw new Error(`${error}`);
+    } finally {
+      await this.alfenApi.apiLogout();
+    }
+
+    return true;
+  }
+
+  async #resumeCharging() {
+    this.log('resumeCharging');
+
+    try {
+      await this.alfenApi.apiLogin();
+      await this.alfenApi.apiSetOperativeMode(0);
+    } catch (error) {
+      this.log('Error resuming charging:', error);
       throw new Error(`${error}`);
     } finally {
       await this.alfenApi.apiLogout();

--- a/drivers/chargepoint/driver.flow.compose.json
+++ b/drivers/chargepoint/driver.flow.compose.json
@@ -273,6 +273,36 @@
                     "label": "A"
                 }
             ]
+        },
+        {
+            "id": "pause_charging",
+            "title": {
+                "en": "Pause charging",
+                "nl": "Laden pauzeren"
+            },
+            "titleFormatted": {
+                "en": "Pause charging",
+                "nl": "Laden pauzeren"
+            },
+            "hint": {
+                "en": "Sets operative mode to In-operative (prop 205F_0 = 2). Station-wide; pauses all sockets. Use for price-driven charging without changing current limit.",
+                "nl": "Zet operative mode op In-operative (prop 205F_0 = 2). Station-wide; pauzeert alle sockets. Bruikbaar voor prijsgestuurd laden zonder de stroomlimiet te wijzigen."
+            }
+        },
+        {
+            "id": "resume_charging",
+            "title": {
+                "en": "Resume charging",
+                "nl": "Laden hervatten"
+            },
+            "titleFormatted": {
+                "en": "Resume charging",
+                "nl": "Laden hervatten"
+            },
+            "hint": {
+                "en": "Sets operative mode back to Operative (prop 205F_0 = 0). Station-wide; resumes all sockets.",
+                "nl": "Zet operative mode terug op Operative (prop 205F_0 = 0). Station-wide; hervat alle sockets."
+            }
         }
     ]
 }

--- a/lib/AlfenApi.ts
+++ b/lib/AlfenApi.ts
@@ -369,6 +369,28 @@ export class AlfenApi {
     return true;
   }
 
+  /**
+   * Operative mode (prop 205F_0): 0 = Operative (resume), 2 = In-operative (pause).
+   * Station-wide (not per socket). Mirrors leeyuentuen/alfen_wallbox select.py
+   * OPERATIVE_MODE_DICT.
+   */
+  async apiSetOperativeMode(value: 0 | 2) {
+    const body = JSON.stringify({
+      '205F_0': {
+        id: '205F_0',
+        value,
+      },
+    });
+
+    try {
+      await this.#apiSetProperty(body);
+    } catch (e) {
+      throw new Error(`Error setting operative mode: ${e}`);
+    }
+
+    return true;
+  }
+
   async apiRebootEvCharger() {
     // Define the request body
     const body = JSON.stringify({


### PR DESCRIPTION
Twee atomaire flow-actions die de operative mode van de wallbox togglen via prop `205F_0`. Station-wide (niet per socket).

## Wijziging

- `pause_charging`: schrijft `205F_0 = 2` (In-operative).
- `resume_charging`: schrijft `205F_0 = 0` (Operative).
- Nieuwe helper `apiSetOperativeMode(0 | 2)` in `AlfenApi.ts`, volgt het bestaande `apiSetXxx`-pattern.
- 2 listeners in `device.ts` met bijbehorende private methods `#pauseCharging` / `#resumeCharging`, identiek aan de `#setCurrentLimit` en `#enableRFID` try/finally style.

## Bron

`leeyuentuen/alfen_wallbox/select.py` `OPERATIVE_MODE_DICT` = {"Operative": 0, "In-operative": 2}, prop `205F_0`.

## Use case

Prijsgestuurd laden via Tibber / Power-by-the-Hour zonder de stroomlimiet aan te raken. Pause als prijs duur wordt, resume als prijs zakt. Atomair.

## Validatie

- `homey app validate -l publish`: groen
- `tsc`: groen
- 3 files changed, +94/-0

## Veiligheid

- Hints waarschuwen expliciet dat het commando station-wide werkt (alle sockets pauzeren/hervatten).
- Alfen handelt graceful disconnect bij pause tijdens active session, geen hardware-risico.
- Wijziging valt buiten de current-limit logic, dus geen interactie met PR #26 socket-2 fix.